### PR TITLE
Connect frontend with backend and resolve duplicate /api issue

### DIFF
--- a/3-tier-app-eks/frontend/nginx.conf
+++ b/3-tier-app-eks/frontend/nginx.conf
@@ -10,7 +10,7 @@ server {
     
     # Proxy /api requests to the backend service
     location /api {
-        proxy_pass http://backend.3-tier-app-eks.svc.cluster.local:8000/api;
+        proxy_pass http://backend.3-tier-app-eks.svc.cluster.local:8000/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/3-tier-app-eks/frontend/src/components/Home.js
+++ b/3-tier-app-eks/frontend/src/components/Home.js
@@ -11,7 +11,7 @@ function Home() {
     const fetchTopics = async () => {
       try {
         setLoading(true);
-        const response = await fetch(`${API_URL}/api/topics`, {
+        const response = await fetch(`${API_URL}/topics`, {
           method: 'GET',
           headers: {
             'Accept': 'application/json',

--- a/3-tier-app-eks/frontend/src/components/QuestionManager.js
+++ b/3-tier-app-eks/frontend/src/components/QuestionManager.js
@@ -36,7 +36,7 @@ function QuestionManager() {
     e.preventDefault();
     setLoading(true);
     try {
-      const response = await fetch(`${API_URL}/api/quiz/questions`, {
+      const response = await fetch(`${API_URL}/quiz/questions`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -108,7 +108,7 @@ function QuestionManager() {
           }
 
           try {
-            const response = await fetch(`${API_URL}/api/quiz/questions/bulk`, {
+            const response = await fetch(`${API_URL}/quiz/questions/bulk`, {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',

--- a/3-tier-app-eks/frontend/src/components/Quiz.js
+++ b/3-tier-app-eks/frontend/src/components/Quiz.js
@@ -14,7 +14,7 @@ function Quiz() {
   const fetchQuiz = useCallback(async () => {
     try {
       setLoading(true);
-      const response = await fetch(`${API_URL}/api/quiz/${topic}`);
+      const response = await fetch(`${API_URL}/quiz/${topic}`);
       if (!response.ok) {
         throw new Error('Failed to fetch quiz');
       }
@@ -59,7 +59,7 @@ function Quiz() {
         answers
       });
 
-      const response = await fetch(`${API_URL}/api/quiz/submit`, {
+      const response = await fetch(`${API_URL}/quiz/submit`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/3-tier-app-eks/frontend/src/config/api.js
+++ b/3-tier-app-eks/frontend/src/config/api.js
@@ -1,3 +1,4 @@
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+const API_URL = process.env.REACT_APP_API_URL?.trim() || 'http://localhost:8000/api';
+
 
 export default API_URL;

--- a/3-tier-app-eks/frontend/src/services/api.js
+++ b/3-tier-app-eks/frontend/src/services/api.js
@@ -3,7 +3,7 @@ import API_URL from '../config/api';
 
 export const fetchTopics = async () => {
   try {
-    const response = await fetch(`${API_URL}/api/topics`);
+    const response = await fetch(`${API_URL}/topics`);
     if (!response.ok) {
       throw new Error(`Error: ${response.status}`);
     }
@@ -17,7 +17,7 @@ export const fetchTopics = async () => {
 // Add other API calls as needed
 export const createTopic = async (topicData) => {
   try {
-    const response = await fetch(`${API_URL}/api/topics`, {
+    const response = await fetch(`${API_URL}/topics`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/3-tier-app-eks/k8s/database-service.yaml
+++ b/3-tier-app-eks/k8s/database-service.yaml
@@ -7,7 +7,7 @@ metadata:
     service: database
 spec:
   type: ExternalName
-  externalName:  akhilesh-postgres.cveph9nmftjh.eu-west-1.rds.amazonaws.com
+  externalName: skymonil-postgres.c54w64eikb30.ap-south-1.rds.amazonaws.com
   ports:
   - port: 5432
   # postgres-db.devopsdozo.svc.cluster.local  

--- a/3-tier-app-eks/k8s/frontend.yaml
+++ b/3-tier-app-eks/k8s/frontend.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: livingdevopswithakhilesh/devopsdozo:frontend-latest
+        image: skymonil/frontend-image:v4
         imagePullPolicy: Always
         ports:
         - containerPort: 80

--- a/3-tier-app-eks/k8s/iam-policy.json
+++ b/3-tier-app-eks/k8s/iam-policy.json
@@ -1,0 +1,251 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeInternetGateways",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeVpcPeeringConnections",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeTags",
+                "ec2:GetCoipPoolUsage",
+                "ec2:DescribeCoipPools",
+                "ec2:GetSecurityGroupsForVpc",
+                "ec2:DescribeIpamPools",
+                "ec2:DescribeRouteTables",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeListenerCertificates",
+                "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:DescribeTrustStores",
+                "elasticloadbalancing:DescribeListenerAttributes",
+                "elasticloadbalancing:DescribeCapacityReservation"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cognito-idp:DescribeUserPoolClient",
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate",
+                "waf-regional:GetWebACL",
+                "waf-regional:GetWebACLForResource",
+                "waf-regional:AssociateWebACL",
+                "waf-regional:DisassociateWebACL",
+                "wafv2:GetWebACL",
+                "wafv2:GetWebACLForResource",
+                "wafv2:AssociateWebACL",
+                "wafv2:DisassociateWebACL",
+                "shield:GetSubscriptionState",
+                "shield:DescribeProtection",
+                "shield:CreateProtection",
+                "shield:DeleteProtection"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateSecurityGroup"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CreateSecurityGroup"
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSecurityGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:DeleteRule"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:ModifyListenerAttributes",
+                "elasticloadbalancing:ModifyCapacityReservation",
+                "elasticloadbalancing:ModifyIpPools"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "elasticloadbalancing:CreateAction": [
+                        "CreateTargetGroup",
+                        "CreateLoadBalancer"
+                    ]
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+            ],
+            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:SetWebAcl",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:AddListenerCertificates",
+                "elasticloadbalancing:RemoveListenerCertificates",
+                "elasticloadbalancing:ModifyRule",
+                "elasticloadbalancing:SetRulePriorities"
+            ],
+            "Resource": "*"
+        }
+    ]
+}


### PR DESCRIPTION
1. Frontend-backend connection issue
The .env variables were not accessible due to being set after the Docker image was built. To fix this, a .env file was added to the build context during image creation, ensuring the frontend has access to REACT_APP_API_URL at runtime.

2. Duplicate /api/api endpoint issue
changed nginx.conf proxy_pass ( Removed /api from proxy_pass)

Removed /api from all fetch queries and appended /api in the config/api.js file.
The app can now wok in both dev and prod just by changing the .env